### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/mattberther/berther.io/security/code-scanning/1](https://github.com/mattberther/berther.io/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/build.yml`, directly under `on:` and before `jobs:`.  
For this workflow, the best minimal safe fix is:

- `contents: read` (required by `actions/checkout` and generally sufficient for source read access)

No functionality changes are needed, and no additional imports/definitions/dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
